### PR TITLE
DB upgrade for show/hide the new classification icon

### DIFF
--- a/src/mysql/install/Install.sql
+++ b/src/mysql/install/Install.sql
@@ -704,6 +704,7 @@ CREATE TABLE list_icon (
     `lst_ic_lst_ID` mediumint(9) unsigned NOT NULL,
     `lst_ic_lst_Option_ID` mediumint(9) unsigned NOT NULL,
     `lst_ic_lst_url` varchar(50) default NULL,
+    `lst_ic_only_person_View` BOOLEAN NOT NULL default 0,
     PRIMARY KEY(lst_ic_id)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 

--- a/src/mysql/upgrade/4.3.0-upgrade.sql
+++ b/src/mysql/upgrade/4.3.0-upgrade.sql
@@ -6,5 +6,6 @@ CREATE TABLE list_icon (
     `lst_ic_lst_ID` mediumint(9) unsigned NOT NULL,
     `lst_ic_lst_Option_ID` mediumint(9) unsigned NOT NULL,
     `lst_ic_lst_url` varchar(50) default NULL,
+    `lst_ic_only_person_View` BOOLEAN NOT NULL default 0,
     PRIMARY KEY(lst_ic_id)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;


### PR DESCRIPTION
#### What's this PR do?
Now a classification icon can be visible only in the PersonView
![capture d ecran 2018-06-30 a 16 46 22](https://user-images.githubusercontent.com/20263693/42126323-e69aa4a6-7c86-11e8-8448-7120aff374b5.png)


#### What Issues does it Close?

Closes

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
