### PR TITLE
Setup steps: slim application error

### DIFF
--- a/src/Include/FooterNotLoggedIn.php
+++ b/src/Include/FooterNotLoggedIn.php
@@ -26,7 +26,7 @@ global $localeInfo;
   <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/input-mask/jquery.inputmask.date.extensions.js"></script>
   <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/input-mask/jquery.inputmask.extensions.js" ></script>
   <script src="<?= SystemURLs::getRootPath() ?>/skin/adminlte/plugins/datepicker/bootstrap-datepicker.js" ></script>
-  <script src="<?= SystemURLs::getRootPath() ?>/locale/js/<?= $localeInfo->getLocale() ?>.js"></script>
+  <?php if ($localeInfo): ?><script src="<?= SystemURLs::getRootPath() ?>/locale/js/<?= $localeInfo->getLocale() ?>.js"></script><?php endif; ?>
 
 
   <!-- Bootbox -->


### PR DESCRIPTION
To avoid this error in setup steps:
Slim Application Error:
Type: Error
Message: Call to a member function getLocale() on null
File: /var/www/ecclesiacrm/src/Include/FooterNotLoggedIn.php
Line: 29

Environment: docker.


#### What's this PR do?


#### What Issues does it Close?

Closes

#### Where should the reviewer start?

#### How should this be manually tested?

#### How should the automated tests treat this?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
