### PR TITLE
Ensure Menu Dashboard render all times

### DIFF
--- a/src/EcclesiaCRM/Dashboard/FamilyDashboardItem.php
+++ b/src/EcclesiaCRM/Dashboard/FamilyDashboardItem.php
@@ -89,7 +89,7 @@ class FamilyDashboardItem implements DashboardItemInterface {
   }
 
   public static function shouldInclude($PageName) {
-    return $PageName == "/Menu.php"; // this ID would be found on all pages.
+    return $PageName == "/Menu.php" || $PageName == "/menu"; // this ID would be found on all pages.
   }
 
 }

--- a/src/EcclesiaCRM/Dashboard/GroupsDashboardItem.php
+++ b/src/EcclesiaCRM/Dashboard/GroupsDashboardItem.php
@@ -35,7 +35,7 @@ class GroupsDashboardItem implements DashboardItemInterface {
   }
 
   public static function shouldInclude($PageName) {
-    return $PageName=="/Menu.php";
+    return $PageName=="/Menu.php" || $PageName == "/menu";
   }
 
 }

--- a/src/EcclesiaCRM/Dashboard/PersonDashboardItem.php
+++ b/src/EcclesiaCRM/Dashboard/PersonDashboardItem.php
@@ -56,7 +56,7 @@ class PersonDashboardItem implements DashboardItemInterface {
   
 
   public static function shouldInclude($PageName) {
-    return $PageName=="/Menu.php"; // this ID would be found on all pages.
+    return $PageName=="/Menu.php" || $PageName == "/menu"; // this ID would be found on all pages.
   }
 
 }

--- a/src/Include/Header-function.php
+++ b/src/Include/Header-function.php
@@ -183,7 +183,7 @@ function Header_body_scripts()
                     "buttons": [ <?= (SessionUser::getUser()->isCreateDirectoryEnabled() )?"'copy', ":""?> <?= (SessionUser::getUser()->isCSVExportEnabled() )?"'csv','excel',":""?> <?= (SessionUser::getUser()->isCreateDirectoryEnabled() )?"'pdf', 'print', ":""?> 'colvis'  ],
                 }
             },
-            PageName:"<?= $_SERVER['PHP_SELF']?>"
+            PageName:"<?= $_SERVER['REQUEST_URI']?>"
         };
     </script>
     <script src="<?= SystemURLs::getRootPath() ?>/skin/js/CRMJSOM.js"></script>


### PR DESCRIPTION
#### What's this PR do?
we have the menu pages at /Menu.php and /menu, /menu did not work with the AJAX call.

1. Support Menu.php and menu on all dashboard Items.
2. Read the URL not the page name in the case of /menu (was reading index.php)

#### What Issues does it Close?

Closes

#### Where should the reviewer start?

#### How should this be manually tested?

- view /Menu.php
- view /menu

#### How should the automated tests treat this?

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
- Is there a related website / article to substantiate / explain this change?
- Does the development wiki need an update?
- Does the user documentation wiki need an update?
- Does this add new dependencies?
